### PR TITLE
Rydd i tester

### DIFF
--- a/src/test/kotlin/no/nav/melosysskattehendelser/PostgresTestContainer.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/PostgresTestContainer.kt
@@ -1,0 +1,26 @@
+package no.nav.melosysskattehendelser
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.PostgreSQLContainer
+
+object PostgresTestContainer {
+    private val container: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:15.2")
+    private const val USE_CONTAINER = true // easy way to switch to run against local docker
+
+    init {
+        if (useTestContainer()) {
+            container.start() // Start the container when this object is accessed
+        }
+    }
+
+    private fun useTestContainer(): Boolean = 
+        System.getenv("USE_LOCAL_DB")?.lowercase() != "true" && USE_CONTAINER
+
+    fun registerPostgresProperties(registry: DynamicPropertyRegistry) {
+        if (useTestContainer()) {
+            registry.add("spring.datasource.url") { container.jdbcUrl }
+            registry.add("spring.datasource.username") { container.username }
+            registry.add("spring.datasource.password") { container.password }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/melosysskattehendelser/PostgresTestContainerBase.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/PostgresTestContainerBase.kt
@@ -1,41 +1,14 @@
 package no.nav.melosysskattehendelser
 
-import org.junit.jupiter.api.AfterEach
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.PostgreSQLContainer
 
 open class PostgresTestContainerBase {
-
-
-    private var dbCleanUpActions = mutableListOf<() -> Unit>()
-
     companion object {
-        var dbContainer = PostgreSQLContainer("postgres:15.2")
-        private const val useContainer = true // easy way to switch to run against local docker
-
-        @DynamicPropertySource
         @JvmStatic
-        fun postgresProperties(registry: DynamicPropertyRegistry) {
-            if (useTestContainer()) {
-                registry.add("spring.datasource.url") { dbContainer.jdbcUrl }
-                registry.add("spring.datasource.password") { dbContainer.password }
-                registry.add("spring.datasource.username") { dbContainer.username }
-
-                dbContainer.start()
-            }
+        @DynamicPropertySource
+        fun registerProperties(registry: DynamicPropertyRegistry) {
+            PostgresTestContainer.registerPostgresProperties(registry)
         }
-
-        private fun useTestContainer(): Boolean =
-            System.getenv("USE_LOCAL_DB")?.lowercase() != "true" && useContainer
-    }
-
-    protected fun addCleanUpAction(deleteAction: () -> Unit) {
-        dbCleanUpActions.add(deleteAction)
-    }
-
-    @AfterEach
-    fun postgresTestContainerBaseAfterEach() {
-        dbCleanUpActions.forEach { it() }
     }
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringDBTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringDBTest.kt
@@ -4,7 +4,6 @@ import io.mockk.mockk
 import no.nav.melosysskattehendelser.domain.PersonRepository
 import no.nav.melosysskattehendelser.domain.SkatteHendelserStatusRepository
 import no.nav.melosysskattehendelser.melosys.KafkaConfig
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -12,7 +11,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
-import org.testcontainers.containers.PostgreSQLContainer
+import org.springframework.test.context.DynamicPropertySource
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -20,7 +19,6 @@ import org.testcontainers.containers.PostgreSQLContainer
 class SkatteHendelsePubliseringDBTest(
     @Autowired override var personRepository: PersonRepository,
     @Autowired override var skatteHendelserStatusRepository: SkatteHendelserStatusRepository,
-    @Autowired private val registry: DynamicPropertyRegistry
 ) : SkatteHendelsePubliseringTest() {
 
     @TestConfiguration
@@ -29,14 +27,11 @@ class SkatteHendelsePubliseringDBTest(
         fun kafkaConfig() = mockk<KafkaConfig>(relaxed = true)
     }
 
-    @BeforeAll
-    fun beforeAll() {
-        PostgreSQLContainer("postgres:15.2").apply {
-            registry.add("spring.datasource.url") { jdbcUrl }
-            registry.add("spring.datasource.password") { password }
-            registry.add("spring.datasource.username") { username }
-        }.run {
-            start()
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerProperties(registry: DynamicPropertyRegistry) {
+            PostgresTestContainer.registerPostgresProperties(registry)
         }
     }
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringDBTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringDBTest.kt
@@ -1,0 +1,42 @@
+package no.nav.melosysskattehendelser
+
+import io.mockk.mockk
+import no.nav.melosysskattehendelser.domain.PersonRepository
+import no.nav.melosysskattehendelser.domain.SkatteHendelserStatusRepository
+import no.nav.melosysskattehendelser.melosys.KafkaConfig
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.PostgreSQLContainer
+
+@ActiveProfiles("test")
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SkatteHendelsePubliseringDBTest(
+    @Autowired override var personRepository: PersonRepository,
+    @Autowired override var skatteHendelserStatusRepository: SkatteHendelserStatusRepository,
+    @Autowired private val registry: DynamicPropertyRegistry
+) : SkatteHendelsePubliseringTest() {
+
+    @TestConfiguration
+    class Config {
+        @Bean // Denne er nødvendig for å slippe å kjøre med @EmbeddedKafka
+        fun kafkaConfig() = mockk<KafkaConfig>(relaxed = true)
+    }
+
+    @BeforeAll
+    fun beforeAll() {
+        PostgreSQLContainer("postgres:15.2").apply {
+            registry.add("spring.datasource.url") { jdbcUrl }
+            registry.add("spring.datasource.password") { password }
+            registry.add("spring.datasource.username") { username }
+        }.run {
+            start()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/SkatteHendelsePubliseringTest.kt
@@ -8,6 +8,7 @@ import no.nav.melosysskattehendelser.melosys.MelosysSkatteHendelse
 import no.nav.melosysskattehendelser.melosys.producer.SkattehendelserProducerFake
 import no.nav.melosysskattehendelser.skatt.Hendelse
 import no.nav.melosysskattehendelser.skatt.SkatteHendelserFetcherFake
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -15,8 +16,8 @@ import java.time.LocalDate
 open class SkatteHendelsePubliseringTest {
     protected open var personRepository: PersonRepository = PersonRepositoryFake()
     protected open var skatteHendelserStatusRepository: SkatteHendelserStatusRepository = SkatteHendelserStatusRepositoryFake()
-    private var skattehendelserProducer: SkattehendelserProducerFake = SkattehendelserProducerFake()
-    private var skatteHendelserFetcher: SkatteHendelserFetcherFake = SkatteHendelserFetcherFake()
+    private val skattehendelserProducer: SkattehendelserProducerFake = SkattehendelserProducerFake()
+    private val skatteHendelserFetcher: SkatteHendelserFetcherFake = SkatteHendelserFetcherFake()
 
     private val skatteHendelsePublisering by lazy {
         SkatteHendelsePublisering(skatteHendelserFetcher, personRepository, skatteHendelserStatusRepository, skattehendelserProducer)
@@ -24,7 +25,6 @@ open class SkatteHendelsePubliseringTest {
 
     @BeforeEach
     fun setUp() {
-        personRepository.deleteAll()
         personRepository
             .apply {
                 save(
@@ -39,6 +39,11 @@ open class SkatteHendelsePubliseringTest {
                         )
                     })
             }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        personRepository.deleteAll()
         skatteHendelserStatusRepository.deleteAll()
         skatteHendelserFetcher.reset()
         skattehendelserProducer.reset()

--- a/src/test/kotlin/no/nav/melosysskattehendelser/domain/PersonRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/domain/PersonRepositoryFake.kt
@@ -44,7 +44,7 @@ class PersonRepositoryFake : PersonRepository {
     }
 
     override fun deleteAll() {
-        throw UnsupportedOperationException("Not yet implemented")
+        items.clear()
     }
 
     override fun deleteById(id: Long) {

--- a/src/test/kotlin/no/nav/melosysskattehendelser/domain/SkatteHendelserStatusRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/domain/SkatteHendelserStatusRepositoryFake.kt
@@ -52,6 +52,6 @@ class SkatteHendelserStatusRepositoryFake : SkatteHendelserStatusRepository {
     }
 
     override fun deleteAll() {
-        throw UnsupportedOperationException("Not yet implemented")
+        items.clear()
     }
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/melosys/KafkaOffsetChecker.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/melosys/KafkaOffsetChecker.kt
@@ -5,9 +5,8 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.TopicPartition
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
-import org.springframework.stereotype.Component
 
-@Component
+
 class KafkaOffsetChecker(
     kafkaProperties: KafkaProperties,
     @Value("\${melosys.kafka.consumer.topic}") private val topic: String,
@@ -20,7 +19,7 @@ class KafkaOffsetChecker(
         )
     ).apply { assign(listOf(topicPartition)) }
 
-    fun getCommittedOffset(): Long {
+    private fun getCommittedOffset(): Long {
         val offsetAndMetadata = consumer.committed(setOf(topicPartition))[topicPartition]
         return offsetAndMetadata?.offset() ?: 0
     }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/melosys/consumer/VedtakHendelseConsumerStopperVedFeilTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/melosys/consumer/VedtakHendelseConsumerStopperVedFeilTest.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 @SpringBootTest
 @DirtiesContext
 @EmbeddedKafka(count = 1, controlledShutdown = true, partitions = 1)
-@Import(KafkaTestProducer::class)
+@Import(KafkaTestProducer::class, KafkaOffsetChecker::class)
 class VedtakHendelseConsumerStopperVedFeilTest(
     @Autowired private val kafkaTemplate: KafkaTemplate<String, String>,
     @Value("\${melosys.kafka.consumer.topic}") private val topic: String,


### PR DESCRIPTION
Det er nå mulig å kjøre SkatteHendelsePublisering testene mot databasen også. Vi kan senere kjør edette i egen konfig, men nå går dette så fort at jeg lar det være som en del av testene. 
Gir mye verdi siden den avslører potensiell fel bruk av DB, og vi får dette gratis siden unit testene gjenbrukes