### PR TITLE
Ignorer perioder med fom/tom som null

### DIFF
--- a/src/main/kotlin/no/nav/melosysskattehendelser/controller/AdminController.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/controller/AdminController.kt
@@ -2,12 +2,14 @@ package no.nav.melosysskattehendelser.controller
 
 import mu.KotlinLogging
 import no.nav.melosysskattehendelser.SkatteHendelsePublisering
+import no.nav.melosysskattehendelser.domain.Periode
+import no.nav.melosysskattehendelser.domain.Person
+import no.nav.melosysskattehendelser.domain.PersonRepository
+import no.nav.melosysskattehendelser.domain.SekvensHistorikk
 import no.nav.security.token.support.core.api.Unprotected
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.server.ResponseStatusException
 
 private val log = KotlinLogging.logger { }
 
@@ -15,7 +17,8 @@ private val log = KotlinLogging.logger { }
 @Unprotected
 @RequestMapping("/admin")
 class AdminController(
-    private val skatteHendelsePublisering: SkatteHendelsePublisering
+    private val skatteHendelsePublisering: SkatteHendelsePublisering,
+    private val personRepository: PersonRepository
 ) {
     @PostMapping("/hendelseprosessering/start")
     fun startHendelseProsessering(): ResponseEntity<String> {
@@ -34,5 +37,42 @@ class AdminController(
     @GetMapping("/hendelseprosessering/status")
     fun status(): ResponseEntity<Map<String, Any>> {
         return ResponseEntity<Map<String, Any>>(skatteHendelsePublisering.status(), HttpStatus.OK)
+    }
+
+    @GetMapping("/person/{id}")
+    fun getPerson(@PathVariable id: Long): ResponseEntity<Map<String,Any?>> {
+        val person = personRepository.findPersonById(id) ?: return ResponseEntity(HttpStatus.NOT_FOUND)
+        return ResponseEntity(person.toMap(), HttpStatus.OK)
+    }
+
+    @GetMapping("/person")
+    fun getPersoner(@RequestParam(defaultValue = "10") max: Int): ResponseEntity<List<Map<String, Any?>>> {
+        val list: List<Map<String, Any?>> = personRepository.findAll()
+            .sortedByDescending { it.id }
+            .take(max)
+            .map { it.toMap() }
+        return ResponseEntity(list, HttpStatus.OK)
+    }
+
+    fun Person.toMap(): Map<String, Any?> = linkedMapOf(
+        "id" to this.id,
+        "ident" to this.ident,
+        "perioder" to this.perioder.map { it.toMap() },
+        "sekvensHistorikk" to this.sekvensHistorikk.map { it.toMap() }
+    )
+
+    fun Periode.toMap(): Map<String, Any?> = linkedMapOf(
+        "id" to this.id,
+        "fom" to this.fom,
+        "tom" to this.tom
+    )
+
+    fun SekvensHistorikk.toMap(): Map<String, Any?> {
+        return linkedMapOf(
+            "id" to this.id,
+            "sekvensnummer" to this.sekvensnummer,
+            "antall" to this.antall,
+            "sisteHendelseTid" to this.sisteHendelseTid
+        )
     }
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/domain/PersonRepository.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/domain/PersonRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.repository.CrudRepository
 
 interface PersonRepository : CrudRepository<Person, Long> {
     fun findPersonByIdent(ident: String): Person?
+    fun findPersonById(id: Long): Person?
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/melosys/consumer/HendelseMelding.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/melosys/consumer/HendelseMelding.kt
@@ -4,8 +4,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import mu.KotlinLogging
 import no.nav.melosysskattehendelser.domain.Person
 import java.time.LocalDate
+
+private val log = KotlinLogging.logger { }
 
 data class MelosysHendelse(
     val melding: HendelseMelding
@@ -26,24 +29,24 @@ data class VedtakHendelseMelding(
     val medlemskapsperiode: Periode? = null
 ) : HendelseMelding() {
 
-    fun toPerson(): Person {
-        return Person(
-            ident = folkeregisterIdent
-        ).apply {
-            medlemskapsperiode?.let {
+    fun toPerson() = Person(ident = folkeregisterIdent).apply {
+        medlemskapsperiode?.let {
+            if (it.fom != null && it.tom != null) {
                 perioder.add(it.toDbPeriode(this))
+            } else {
+                log.warn { "Forsøkte å legge til periode med fom:${it.fom} tom:${it.tom} for $ident" }
             }
         }
     }
 }
 
 data class Periode(
-    val fom: LocalDate,
-    val tom: LocalDate
+    val fom: LocalDate?,
+    val tom: LocalDate?
 ) {
     fun toDbPeriode(person: Person) = no.nav.melosysskattehendelser.domain.Periode(
-        fom = fom,
-        tom = tom,
+        fom = fom ?: throw IllegalArgumentException("fom kan ikke være null"),
+        tom = tom ?: throw IllegalArgumentException("tom kan ikke være null"),
         person = person
     )
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/melosys/consumer/VedtakHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/melosys/consumer/VedtakHendelseConsumer.kt
@@ -35,9 +35,13 @@ class VedtakHendelseConsumer(
                     return
                 }
 
-                log.info("legger til periode $periode på person")
-                person.perioder.add(periode.toDbPeriode(person))
-                vedtakHendelseRepository.save(person)
+                if (periode.erGyldig()) {
+                    log.info("legger til periode $periode på person med id: ${person.id}")
+                    person.leggTilPeriode(periode)
+                    vedtakHendelseRepository.save(person)
+                } else {
+                    log.warn { "Forsøkte å legge til periode med fom:${periode.fom} tom:${periode.tom} for person med id: ${person.id}" }
+                }
             }
             return
         }
@@ -47,5 +51,13 @@ class VedtakHendelseConsumer(
 
     private fun Person.harPeriode(periode: Periode) = perioder.any {
         it.fom == periode.fom && it.tom == periode.tom
+    }
+
+    private fun Person.leggTilPeriode(periode: Periode) {
+        perioder.add(periode.toDbPeriode(this))
+    }
+
+    private fun Periode.erGyldig(): Boolean {
+        return fom != null && tom != null
     }
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/domain/PersonRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/domain/PersonRepositoryFake.kt
@@ -5,12 +5,11 @@ import java.util.*
 class PersonRepositoryFake : PersonRepository {
     private val items = mutableMapOf<Long, Person>()
 
-    fun reset() = apply {
-        items.clear()
-    }
-
     override fun findPersonByIdent(ident: String): Person? =
         items.values.find { it.ident == ident }
+
+    override fun findPersonById(id: Long): Person? =
+        items.values.find { it.id == id }
 
     override fun <S : Person?> save(entity: S & Any): S & Any {
         items[entity.id] = entity

--- a/src/test/kotlin/no/nav/melosysskattehendelser/melosys/consumer/MelosysHendelseTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/melosys/consumer/MelosysHendelseTest.kt
@@ -175,5 +175,40 @@ class MelosysHendelseTest {
             .properties.shouldBe(mapOf("pnr" to "12345"))
     }
 
+    @Test
+    fun `deserialize VedtakHendelseMelding med periode hvor fom eller-og tom er null`() {
+        val json = """
+            {
+                "melding": {
+                    "type": "VedtakHendelseMelding",
+                    "folkeregisterIdent": "12345",
+                    "sakstype": "TRYGDEAVTALE",
+                    "sakstema": "TRYGDEAVGIFT",
+                    "medlemskapsperiode": {
+                          "fom": null,
+                          "tom": null
+                    }
+                    
+                }
+            }"""
+
+
+        val result = objectMapper.readValue<MelosysHendelse>(json)
+
+
+        result.melding.shouldBe(
+            VedtakHendelseMelding(
+                folkeregisterIdent = "12345",
+                sakstype = Sakstyper.TRYGDEAVTALE,
+                sakstema = Sakstemaer.TRYGDEAVGIFT,
+                medlemskapsperiode = Periode(
+                    null,
+                    null
+                )
+            )
+        )
+    }
+
+
     private fun Any.toJson(): String = objectMapper.valueToTree<JsonNode?>(this).toPrettyString()
 }


### PR DESCRIPTION
Når vi får kafka melding fra melosys-api og periode inneholder fom og/eller tom som er null så ignoreres perioden