### PR TITLE
7224 legg til mer jobb kjøring stats

### DIFF
--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/JobMonitor.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/JobMonitor.kt
@@ -159,17 +159,3 @@ class JobMonitor<T : JobMonitor.Stats>(
         fun asMap(): Map<String, Any>
     }
 }
-
-inline fun <T> measure(
-    statsMap: MutableMap<String, AtomicLong>,
-    methodName: String,
-    block: () -> T
-): T {
-    val start = System.nanoTime()
-    try {
-        return block()
-    } finally {
-        val duration = System.nanoTime() - start
-        statsMap.computeIfAbsent(methodName) { AtomicLong(0) }.addAndGet(duration)
-    }
-}

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/JobMonitor.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/JobMonitor.kt
@@ -88,9 +88,12 @@ class JobMonitor<T : JobMonitor.Stats>(
         }
         isRunning = true
         startedAt = LocalDateTime.now()
+        stoppedAt = null
         errorCount = 0
         exceptions.clear()
         stats.reset()
+        methodToNanoTime.clear()
+        methodToCount.clear()
         return try {
             stats.block()
         } catch (ex: Exception) {
@@ -108,7 +111,7 @@ class JobMonitor<T : JobMonitor.Stats>(
         }
     }
 
-     fun registerException(e: Throwable) {
+     private fun registerException(e: Throwable) {
         val msg = e.message ?: e::class.simpleName ?: "Unknown error"
         exceptions[msg] = exceptions.getOrDefault(msg, 0) + 1
         if (errorCount++ >= maxErrorsBeforeStop) {

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/MonitorExtensions.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/MonitorExtensions.kt
@@ -1,0 +1,17 @@
+package no.nav.melosysskattehendelser.prosessering
+
+import java.util.concurrent.atomic.AtomicLong
+
+inline fun <T> measure(
+    statsMap: MutableMap<String, AtomicLong>,
+    methodName: String,
+    block: () -> T
+): T {
+    val start = System.nanoTime()
+    try {
+        return block()
+    } finally {
+        val duration = System.nanoTime() - start
+        statsMap.computeIfAbsent(methodName) { AtomicLong(0) }.addAndGet(duration)
+    }
+}

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
@@ -51,7 +51,7 @@ class SkatteHendelsePublisering(
             reportStats = { stats ->
                 antallBatcher = stats.antallBatcher
                 sisteBatchSize = stats.sisteBatchSize
-                jobMonitor.registerMetodeMedTidBrukt("hentSkatteHendelser", stats.nanoSecUsed)
+                jobMonitor.sampleMethod(stats.metodeStats)
             }
         ).forEach { hendelse ->
             if (jobMonitor.shouldStop) return@forEach

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
@@ -58,6 +58,7 @@ class SkatteHendelsePublisering(
             totaltAntallHendelser++
             gjelderPeriodeToCount.incrementCount(hendelse.gjelderPeriode)
             registreringstidspunktToCount.incrementCount(hendelse.registreringstidspunktAsYearMonth())
+            hendelsetypeToCount.incrementCount(hendelse.hendelsetype)
             finnPersonMedTreffIGjelderPeriode(hendelse)?.let { person ->
                 metrikker.personFunnet()
                 personerFunnet++
@@ -117,8 +118,9 @@ class SkatteHendelsePublisering(
         @Volatile var sisteSekvensnummer: Long = 0,
         @Volatile var antallBatcher: Int = 0,
         @Volatile var sisteBatchSize: Int = 0,
-        var gjelderPeriodeToCount: ConcurrentHashMap<String, Int> = ConcurrentHashMap(),
-        var registreringstidspunktToCount: ConcurrentHashMap<String, Int> = ConcurrentHashMap()
+        val gjelderPeriodeToCount: ConcurrentHashMap<String, Int> = ConcurrentHashMap(),
+        val registreringstidspunktToCount: ConcurrentHashMap<String, Int> = ConcurrentHashMap(),
+        val hendelsetypeToCount: ConcurrentHashMap<String, Int> = ConcurrentHashMap()
     ) : JobMonitor.Stats {
         override fun reset() {
             totaltAntallHendelser = 0
@@ -136,6 +138,7 @@ class SkatteHendelsePublisering(
             "sisteSekvensnummer" to sisteSekvensnummer,
             "antallBatcher" to antallBatcher,
             "sisteBatchSize" to sisteBatchSize,
+            "hendelsetypeToCount" to hendelsetypeToCount,
             "gjelderPeriodeToCount" to gjelderPeriodeToCount,
             "registreringstidspunktToCount" to registreringstidspunktToCount
         )

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
@@ -133,6 +133,7 @@ class SkatteHendelsePublisering(
             sisteBatchSize = 0
             gjelderPeriodeToCount.clear()
             registreringstidspunktToCount.clear()
+            hendelsetypeToCount.clear()
         }
 
         override fun asMap() = mapOf(

--- a/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/prosessering/SkatteHendelsePublisering.kt
@@ -51,7 +51,7 @@ class SkatteHendelsePublisering(
             reportStats = { stats ->
                 antallBatcher = stats.antallBatcher
                 sisteBatchSize = stats.sisteBatchSize
-                jobMonitor.sampleMethod(stats.metodeStats)
+                jobMonitor.importMethodMetrics(stats.metodeStats)
             }
         ).forEach { hendelse ->
             if (jobMonitor.shouldStop) return@forEach
@@ -97,7 +97,7 @@ class SkatteHendelsePublisering(
     }
 
     private fun finnPersonMedTreffIGjelderPeriode(hendelse: Hendelse): Person? =
-        jobMonitor.sampleMethod("finnPersonMedTreffIGjelderPeriode") {
+        jobMonitor.measureExecution("finnPersonMedTreffIGjelderPeriode") {
             personRepository.findPersonByIdent(hendelse.identifikator)?.takeIf { person ->
                 person.harTreffIPeriode(hendelse.gjelderPeriodeSomÅr())
             }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
@@ -21,12 +21,12 @@ data class HendelseRequest(
 data class Hendelse(
     val gjelderPeriode: String,
     val identifikator: String,
-    val registreringstidspunkt: String,
     val sekvensnummer: Long,
     val somAktoerid: Boolean,
     @JsonSetter(nulls = Nulls.SKIP)
-    val hendelsetype: String = "ny"
+    val hendelsetype: String = "ny",
+    val registreringstidspunkt: String? = null
 ) {
     fun gjelderPeriodeSomÅr() = Year.parse(gjelderPeriode).value
-    fun registreringstidspunktAsYearMonth() = registreringstidspunkt.substring(0,7)
+    fun registreringstidspunktAsYearMonth() = registreringstidspunkt?.substring(0,7) ?: "null"
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
@@ -24,7 +24,7 @@ data class Hendelse(
     val sekvensnummer: Long,
     val somAktoerid: Boolean,
     @JsonSetter(nulls = Nulls.SKIP)
-    val hendelsetype: String = "ny",
+    val hendelsetype: String = "ukjent",
     val registreringstidspunkt: String? = null
 ) {
     fun gjelderPeriodeSomÅr() = Year.parse(gjelderPeriode).value

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelseConsumer.kt
@@ -21,10 +21,12 @@ data class HendelseRequest(
 data class Hendelse(
     val gjelderPeriode: String,
     val identifikator: String,
+    val registreringstidspunkt: String,
     val sekvensnummer: Long,
     val somAktoerid: Boolean,
     @JsonSetter(nulls = Nulls.SKIP)
     val hendelsetype: String = "ny"
 ) {
     fun gjelderPeriodeSomÅr() = Year.parse(gjelderPeriode).value
+    fun registreringstidspunktAsYearMonth() = registreringstidspunkt.substring(0,7)
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcher.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcher.kt
@@ -14,7 +14,8 @@ interface SkatteHendelserFetcher {
     data class Stats(
         val totaltAntallHendelser: Int,
         val antallBatcher: Int,
-        val sisteBatchSize: Int
+        val sisteBatchSize: Int,
+        val nanoSecUsed: Long = 0
     ) {
         fun applyReport(reportStats: (Stats) -> Unit) {
             reportStats(this)

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcher.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcher.kt
@@ -1,5 +1,7 @@
 package no.nav.melosysskattehendelser.skatt
 
+import java.util.concurrent.atomic.AtomicLong
+
 interface SkatteHendelserFetcher {
     fun hentHendelser(
         startSeksvensnummer: Long,
@@ -15,7 +17,7 @@ interface SkatteHendelserFetcher {
         val totaltAntallHendelser: Int,
         val antallBatcher: Int,
         val sisteBatchSize: Int,
-        val nanoSecUsed: Long = 0
+        val metodeStats : Map<String, AtomicLong>,
     ) {
         fun applyReport(reportStats: (Stats) -> Unit) {
             reportStats(this)

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcherAPI.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcherAPI.kt
@@ -1,10 +1,12 @@
 package no.nav.melosysskattehendelser.skatt
 
 import mu.KotlinLogging
+import no.nav.melosysskattehendelser.prosessering.measure
 import no.nav.melosysskattehendelser.skatt.SkatteHendelserFetcher.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.util.concurrent.atomic.AtomicLong
 
 private val log = KotlinLogging.logger { }
 
@@ -29,9 +31,10 @@ class SkatteHendelserFetcherAPI(
         var totaltAntallHendelser = 0
         var antallBatcher = 0
         while (true) {
-            val start = System.nanoTime()
-            hendelseListe = hentSkatteHendelser(seksvensnummerFra)
-            val nanoSecUsed = System.nanoTime() - start
+            val metodeStats = mutableMapOf<String, AtomicLong>()
+            hendelseListe = measure(metodeStats, "hentSkatteHendelser") {
+                hentSkatteHendelser(seksvensnummerFra)
+            }
             if (hendelseListe.size > batchSize) error("hendelseListe.size ${hendelseListe.size} > batchSize $batchSize")
             val last = hendelseListe.lastOrNull() ?: break
             log.info(
@@ -45,11 +48,10 @@ class SkatteHendelserFetcherAPI(
                 totaltAntallHendelser = totaltAntallHendelser,
                 antallBatcher = ++antallBatcher,
                 sisteBatchSize = hendelseListe.size,
-                nanoSecUsed = nanoSecUsed
-
+                metodeStats = metodeStats
             ).applyReport(reportStats)
         }
-        log.info("totalt antall hendelser prossessert: $totaltAntallHendelser seksvensnummerFra er nå: $seksvensnummerFra")
+        log.info("totalt antall hendelser prosessert: $totaltAntallHendelser seksvensnummerFra er nå: $seksvensnummerFra")
     }
 
     private fun hentSkatteHendelser(seksvensnummerFra: Long) = skatteHendelseConsumer.hentHendelseListe(

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcherAPI.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/SkatteHendelserFetcherAPI.kt
@@ -15,7 +15,7 @@ class SkatteHendelserFetcherAPI(
     @Value("\${skatt.fetcher.start-dato}") private val startDato: LocalDate
 ) : SkatteHendelserFetcher {
     init {
-        log.info("batchSize er satt til $batchSize")
+        log.info("batchSize er satt til $batchSize, startDato er satt til $startDato")
     }
 
 

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunRestConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunRestConsumerTest.kt
@@ -75,8 +75,8 @@ class SigrunRestConsumerTest {
 
         hendelseListe
             .shouldContainExactly(
-                Hendelse("2023", "123456", 0, true, hendelsetype = "ny"),
-                Hendelse("2023", "456789", 1, true, hendelsetype = "ny")
+                Hendelse("2023", "123456", 0, true, hendelsetype = "ukjent"),
+                Hendelse("2023", "456789", 1, true, hendelsetype = "ukjent")
             )
     }
 


### PR DESCRIPTION
Brukes til å få oversikt over 
* hendelsetype
* registreringstidspunkt
* gjelderPeriode
* Utvidet job monitor
* Lagt på profiling av tid brukt mot database samt Sigrun hendelse api