### PR TITLE
Oppdatere sigrun_host og sigrun_rest_url

### DIFF
--- a/nais/vars-prod.json
+++ b/nais/vars-prod.json
@@ -12,7 +12,7 @@
   "cluster_sigrun": "prod-fss",
   "app_name_sigrun": "sigrun",
   "app_name_melosys_console": "melosys-console",
-  "sigrun_host": "team-inntekt-proxy.prod-fss-pub.nais.io",
-  "sigrun_rest_url": "https://team-inntekt-proxy.prod-fss-pub.nais.io/proxy/sigrun"
+  "sigrun_host": "sigrun.prod-fss-pub.nais.io",
+  "sigrun_rest_url": "https://sigrun.prod-fss-pub.nais.io"
 
 }


### PR DESCRIPTION
https://team-inntekt-proxy.prod-fss-pub.nais.io/proxy/sigrun/api/v1/pensjonsgivendeinntektforfolketrygden/hendelser er fjernet 

Så vi skal nå bruke https://sigrun.prod-fss-pub.nais.io/api/v1/pensjonsgivendeinntektforfolketrygden/hendelser 