### PR TITLE
NOJIRA Logg statuskode når Sigrun svarer uten body

### DIFF
--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -6,6 +6,7 @@ import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektRequest
 import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektResponse
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
@@ -34,7 +35,18 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
                         )
                     }
 
-                    status.isError -> response.createException().flatMap { Mono.error(it) }
+                    status.isError -> response.createException().flatMap { exception ->
+                        log.error {
+                            "PensjonsgivendeInntekt api feilet - status: $status" +
+                                ", inntektsaar: ${request.inntektsaar}" +
+                                ", Nav-Call-Id: ${response.requestHeader("Nav-Call-Id")}" +
+                                ", rettighetspakke: ${response.requestHeader("rettighetspakke")}" +
+                                ", Nav-Consumer-Id: ${response.requestHeader("Nav-Consumer-Id")}" +
+                                ", responseHeaders: ${response.headers().asHttpHeaders()}" +
+                                ", body: ${exception.responseBodyAsString}"
+                        }
+                        Mono.error(exception)
+                    }
 
                     else -> response.bodyToMono(PensjonsgivendeInntektResponse::class.java)
                         .switchIfEmpty(
@@ -49,3 +61,11 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
             .block() ?: throw IllegalStateException("Ingen body - kunne ikke hente PensjonsgivendeInntektResponse")
     }
 }
+
+/**
+ * Leser en header fra det utgående kallet. Kun headere uten personopplysninger skal logges,
+ * derfor hentes de eksplisitt én og én i stedet for å dumpe alle (Authorization og
+ * Nav-Personident må aldri havne i loggen).
+ */
+private fun ClientResponse.requestHeader(name: String): String? =
+    request().headers.getFirst(name)

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -20,18 +20,30 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
             .header("Nav-Personident", request.navPersonident)
             .header("inntektsaar", request.inntektsaar)
             .exchangeToMono { response ->
-                if (response.statusCode() == HttpStatus.NOT_FOUND) {
-                    log.warn { "PensjonsgivendeInntekt api status: 404 NOT_FOUND" }
-                    Mono.just(
-                        PensjonsgivendeInntektResponse(
-                            slettet = true,
-                            norskPersonidentifikator = request.navPersonident,
-                            inntektsaar = request.inntektsaar,
-                            pensjonsgivendeInntekt = emptyList()
+                val status = response.statusCode()
+                when {
+                    status == HttpStatus.NOT_FOUND -> {
+                        log.warn { "PensjonsgivendeInntekt api status: 404 NOT_FOUND" }
+                        Mono.just(
+                            PensjonsgivendeInntektResponse(
+                                slettet = true,
+                                norskPersonidentifikator = request.navPersonident,
+                                inntektsaar = request.inntektsaar,
+                                pensjonsgivendeInntekt = emptyList()
+                            )
                         )
-                    )
-                } else {
-                    response.bodyToMono(PensjonsgivendeInntektResponse::class.java)
+                    }
+
+                    status.isError -> response.createException().flatMap { Mono.error(it) }
+
+                    else -> response.bodyToMono(PensjonsgivendeInntektResponse::class.java)
+                        .switchIfEmpty(
+                            Mono.error(
+                                IllegalStateException(
+                                    "Ingen body - kunne ikke hente PensjonsgivendeInntektResponse, status: $status"
+                                )
+                            )
+                        )
                 }
             }
             .block() ?: throw IllegalStateException("Ingen body - kunne ikke hente PensjonsgivendeInntektResponse")

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -42,8 +42,8 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
                                 ", Nav-Call-Id: ${response.requestHeader("Nav-Call-Id")}" +
                                 ", rettighetspakke: ${response.requestHeader("rettighetspakke")}" +
                                 ", Nav-Consumer-Id: ${response.requestHeader("Nav-Consumer-Id")}" +
-                                ", responseHeaders: ${response.headers().asHttpHeaders()}" +
-                                ", body: ${exception.responseBodyAsString}"
+                                ", responseHeaders: ${response.loggbareResponseHeadere()}" +
+                                ", body: ${exception.responseBodyAsString.maskertOgAvkortet()}"
                         }
                         Mono.error(exception)
                     }
@@ -69,3 +69,32 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
  */
 private fun ClientResponse.requestHeader(name: String): String? =
     request().headers.getFirst(name)
+
+/**
+ * Response-headere fra Sigrun er utenfor vår kontroll - vi vet ikke hva Sigrun eller proxyen
+ * foran den sender tilbake (ekko av ident, Set-Cookie fra en gateway, ...). Derfor logges kun
+ * en allow-liste, av samme grunn som request-headerne over hentes én og én.
+ */
+private val LOGGBARE_RESPONSE_HEADERE = listOf("Nav-Call-Id", "x-request-id", "Retry-After", "Content-Type")
+
+private fun ClientResponse.loggbareResponseHeadere(): String =
+    headers().asHttpHeaders()
+        .let { headere -> LOGGBARE_RESPONSE_HEADERE.mapNotNull { navn -> headere.getFirst(navn)?.let { "$navn=$it" } } }
+        .joinToString(prefix = "[", postfix = "]")
+
+private const val MAKS_BODY_LENGDE = 500
+
+/**
+ * Sifferserier på 11-13 tegn - fødselsnummer, d-nummer og aktørid. Samme intensjon som
+ * masken i logback.xml, men den er kun aktiv i prod-clusteret; her gjelder den i alle miljøer.
+ */
+private val PERSONIDENTIFIKATOR = Regex("""(^|\W)\d{11,13}(?=$|\W)""")
+
+/**
+ * Feilbodyen fra Sigrun er fritekst vi ikke eier og kan inneholde personidentifikatorer
+ * (typisk "Ugyldig personidentifikator: <fnr>"), så den maskeres før logging. Den avkortes
+ * også: svarer proxyen med en HTML-feilside blir bodyen titusenvis av tegn på én loggslinje.
+ */
+private fun String.maskertOgAvkortet(): String =
+    PERSONIDENTIFIKATOR.replace(take(MAKS_BODY_LENGDE)) { "${it.groupValues[1]}***********" }
+        .let { if (length > MAKS_BODY_LENGDE) "$it...[avkortet, $length tegn totalt]" else it }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -35,7 +35,11 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
                         )
                     }
 
-                    status.isError -> response.createException().flatMap { exception ->
+                    // Alt som ikke er 2xx behandles som feil. Med status.isError ville en 3xx
+                    // (f.eks. redirect til innlogging fra gatewayen) havnet i else-grenen og
+                    // blitt rapportert som "Ingen body" - nettopp den intetsigende meldingen
+                    // denne håndteringen finnes for å unngå.
+                    !status.is2xxSuccessful -> response.createException().flatMap { exception ->
                         log.error {
                             "PensjonsgivendeInntekt api feilet - status: $status" +
                                 ", inntektsaar: ${request.inntektsaar}" +
@@ -49,6 +53,18 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
                     }
 
                     else -> response.bodyToMono(PensjonsgivendeInntektResponse::class.java)
+                        // Et 2xx-svar med en body som ikke er en PensjonsgivendeInntektResponse
+                        // deserialiseres stille til et objekt med bare nullfelt og tom inntektsliste.
+                        // Det tolkes nedstrøms som en gyldig endring og publiseres. Samme feilklasse
+                        // som feilsvarene over, bare på 2xx, så den må fanges her.
+                        .flatMap { body ->
+                            if (body.norskPersonidentifikator == null) Mono.error(
+                                IllegalStateException(
+                                    "Uventet body fra PensjonsgivendeInntekt api - " +
+                                        "norskPersonidentifikator mangler, status: $status"
+                                )
+                            ) else Mono.just(body)
+                        }
                         .switchIfEmpty(
                             Mono.error(
                                 IllegalStateException(

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -1,5 +1,9 @@
 package no.nav.melosysskattehendelser.skatt.sigrun
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -8,14 +12,19 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektRequest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SigrunPensjonsgivendeInntektConsumerTest {
@@ -152,6 +161,48 @@ class SigrunPensjonsgivendeInntektConsumerTest {
                 PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141641")
             )
         }.statusCode.value() shouldBe 500
+    }
+
+    @Test
+    fun `skal logge statuskode, body og Nav-Call-Id ved 403 uten å lekke personident`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141642")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(403)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("""{"melding":"Mangler tilgang til rettighetspakke navtrygdeavgift"}""")
+                )
+        )
+        val consumerMedCallId = SigrunPensjonsgivendeInntektConsumer(
+            WebClient.builder()
+                .baseUrl("http://localhost:${wireMockServer.port()}")
+                .filter(ExchangeFilterFunction.ofRequestProcessor { request ->
+                    Mono.just(ClientRequest.from(request).header("Nav-Call-Id", "CallId_test_123").build())
+                })
+                .build()
+        )
+
+        val logg = ListAppender<ILoggingEvent>().apply { start() }
+        val logger = LoggerFactory.getLogger("no.nav.melosysskattehendelser.skatt.sigrun") as Logger
+        logger.addAppender(logg)
+
+        try {
+            shouldThrow<WebClientResponseException> {
+                consumerMedCallId.hentPensjonsgivendeInntekt(
+                    PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141642")
+                )
+            }.statusCode.value() shouldBe 403
+        } finally {
+            logger.detachAppender(logg)
+        }
+
+        val melding = logg.list.single { it.level == Level.ERROR }.formattedMessage
+        melding shouldContain "403"
+        melding shouldContain "Mangler tilgang til rettighetspakke navtrygdeavgift"
+        melding shouldContain "CallId_test_123"
+        melding shouldContain "inntektsaar: 2024"
+        melding shouldNotContain "26468141642"
     }
 
     private fun createGetRequest(navPersonident: String): MappingBuilder =

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -4,8 +4,10 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektRequest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SigrunPensjonsgivendeInntektConsumerTest {
@@ -34,7 +37,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal hente inntekt`() {
         wireMockServer.stubFor(
-            createGetRequest()
+            createGetRequest("26468141638")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(200)
@@ -79,7 +82,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal håntere 404`() {
         wireMockServer.stubFor(
-            createGetRequest()
+            createGetRequest("26468141637")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(404)
@@ -90,7 +93,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         val inntekt = sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
             PensjonsgivendeInntektRequest(
                 inntektsaar = "2024",
-                navPersonident = "26468141638"
+                navPersonident = "26468141637"
             )
         )
 
@@ -98,6 +101,60 @@ class SigrunPensjonsgivendeInntektConsumerTest {
 
     }
 
-    private fun createGetRequest(): MappingBuilder =
+    @Test
+    fun `skal kaste feil med statuskode nar 2xx svar mangler body`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141639")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(204)
+                )
+        )
+
+        shouldThrow<IllegalStateException> {
+            sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141639")
+            )
+        }.message shouldContain "204"
+    }
+
+    @Test
+    fun `skal kaste feil med statuskode nar api svarer 500 uten body`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141640")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(500)
+                )
+        )
+
+        shouldThrow<WebClientResponseException> {
+            sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141640")
+            )
+        }.statusCode.value() shouldBe 500
+    }
+
+    @Test
+    fun `skal ikke tolke feilmelding-body fra 500 som tom inntekt`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141641")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(500)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("""{"melding":"Intern feil i Sigrun"}""")
+                )
+        )
+
+        shouldThrow<WebClientResponseException> {
+            sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141641")
+            )
+        }.statusCode.value() shouldBe 500
+    }
+
+    private fun createGetRequest(navPersonident: String): MappingBuilder =
         WireMock.get(WireMock.urlPathEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
+            .withHeader("Nav-Personident", WireMock.equalTo(navPersonident))
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -261,6 +261,43 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         melding.length shouldBeLessThan 1000
     }
 
+    @Test
+    fun `skal behandle 3xx som feil og ikke som manglende body`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141645")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(302)
+                        .withHeader(HttpHeaders.LOCATION, "https://login.microsoftonline.com/")
+                )
+        )
+
+        shouldThrow<WebClientResponseException> {
+            sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141645")
+            )
+        }.statusCode.value() shouldBe 302
+    }
+
+    @Test
+    fun `skal ikke tolke uventet body fra 200 som tom inntekt`() {
+        wireMockServer.stubFor(
+            createGetRequest("26468141646")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("""{"melding":"Noe helt annet enn en inntektsrespons"}""")
+                )
+        )
+
+        shouldThrow<IllegalStateException> {
+            sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = "26468141646")
+            )
+        }.message shouldContain "norskPersonidentifikator mangler"
+    }
+
     private fun fangErrorLogg(block: () -> Unit): String {
         val logg = ListAppender<ILoggingEvent>().apply { start() }
         val logger = LoggerFactory.getLogger("no.nav.melosysskattehendelser.skatt.sigrun") as Logger

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -10,6 +10,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -164,7 +165,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     }
 
     @Test
-    fun `skal logge statuskode, body og Nav-Call-Id ved 403 uten å lekke personident`() {
+    fun `skal logge statuskode, body og Nav-Call-Id ved 403`() {
         wireMockServer.stubFor(
             createGetRequest("26468141642")
                 .willReturn(
@@ -202,7 +203,74 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         melding shouldContain "Mangler tilgang til rettighetspakke navtrygdeavgift"
         melding shouldContain "CallId_test_123"
         melding shouldContain "inntektsaar: 2024"
-        melding shouldNotContain "26468141642"
+    }
+
+    @Test
+    fun `skal maskere personident i body og utelate ukjente response-headere`() {
+        val navPersonident = "26468141643"
+        wireMockServer.stubFor(
+            createGetRequest(navPersonident)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(400)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withHeader("Nav-Personident", navPersonident)
+                        .withHeader("Set-Cookie", "session=hemmelig-token-abc123")
+                        .withBody("""{"melding":"Ugyldig personidentifikator: $navPersonident for inntektsaar 2024"}""")
+                )
+        )
+
+        val melding = fangErrorLogg {
+            shouldThrow<WebClientResponseException> {
+                sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                    PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = navPersonident)
+                )
+            }.statusCode.value() shouldBe 400
+        }
+
+        melding shouldContain "400"
+        melding shouldContain "Ugyldig personidentifikator"
+        melding shouldContain "***********"
+        melding shouldNotContain navPersonident
+        melding shouldNotContain "hemmelig-token-abc123"
+    }
+
+    @Test
+    fun `skal avkorte lang feilbody`() {
+        val navPersonident = "26468141644"
+        val langBody = "<html>" + "x".repeat(20_000) + "</html>"
+        wireMockServer.stubFor(
+            createGetRequest(navPersonident)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(502)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
+                        .withBody(langBody)
+                )
+        )
+
+        val melding = fangErrorLogg {
+            shouldThrow<WebClientResponseException> {
+                sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+                    PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = navPersonident)
+                )
+            }.statusCode.value() shouldBe 502
+        }
+
+        melding shouldContain "avkortet, ${langBody.length} tegn totalt"
+        melding.length shouldBeLessThan 1000
+    }
+
+    private fun fangErrorLogg(block: () -> Unit): String {
+        val logg = ListAppender<ILoggingEvent>().apply { start() }
+        val logger = LoggerFactory.getLogger("no.nav.melosysskattehendelser.skatt.sigrun") as Logger
+        logger.addAppender(logg)
+        try {
+            block()
+        } finally {
+            logger.detachAppender(logg)
+        }
+        return logg.list.single { it.level == Level.ERROR }.formattedMessage
     }
 
     private fun createGetRequest(navPersonident: String): MappingBuilder =


### PR DESCRIPTION
Skiller feilhåndteringen mot Sigrun sitt pensjonsgivendeinntekt-API i tre grener, slik at feilmeldingen alltid inneholder statuskoden.

Tidligere ga alle bodyløse svar utenom 404 samme melding — "Ingen body - kunne ikke hente PensjonsgivendeInntektResponse" — uten statuskode. Da er det umulig å skille et forventet 204 fra nedetid eller throttling når feilen dukker opp i prod. Siden `exchangeToMono` slår av standardhåndteringen av 4xx og 5xx, ble i tillegg et feilsvar med JSON-body deserialisert stille til et gyldig objekt med tom inntektsliste, og dermed tolket som "ingen inntekt" i stedet for å feile.

- 404 håndteres uendret og gir fortsatt `slettet = true`
- Andre feilstatuser kaster `WebClientResponseException` med statuskode og body
- 2xx uten body kaster `IllegalStateException` med statuskoden i meldingen
- WireMock-stubbene i testen bindes til hver sin `Nav-Personident`, ellers overskrev de hverandre

## Testing
- [x] Enhetstester for 204 uten body, 500 uten body og 500 med feilmelding-body
- [ ] Manuell testing lokalt
- [ ] E2E-tester (ikke relevant)

## Notater
Spørsmål er sendt til SKE-teamet om hvilke bodyløse svar API-et faktisk returnerer (er 204 forventet ved manglende fastsatt inntekt, eller er 404 alltid svaret?). Denne PR-en gjør oss i stand til å se statuskoden i prod uavhengig av svaret.

`./gradlew test` har 11 preeksisterende feil på master som skyldes Testcontainers/Docker — ikke relatert til denne endringen.