### PR TITLE
8187 Oppgrader fra Java 17 til Java 21

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v6.0.3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5.6.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup gradle dependency cache
         uses: actions/cache@v5

--- a/.github/workflows/deploy-manuelt.yml
+++ b/.github/workflows/deploy-manuelt.yml
@@ -46,10 +46,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5.6.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup gradle dependency cache
         uses: actions/cache@v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5.6.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian12:nonroot
+FROM gcr.io/distroless/java21-debian12:nonroot
 LABEL maintainer="Team Melosys"
 COPY /build/libs/melosys-skattehendelser.jar /app/app.jar
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
 group = "no.nav.melosys"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
@@ -92,7 +94,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         freeCompilerArgs.add("-Xjsr305=strict")
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 


### PR DESCRIPTION
Oppgraderer melosys-skattehendelser fra Java 17 til Java 21.
[MELOSYS-8187](https://nav.atlassian.net/browse/MELOSYS-8187)

- Gradle-toolchain låst til JDK 21 (erstatter `sourceCompatibility`)
- Kotlin `jvmTarget` hevet til `JVM_21`
- Runtime-image `distroless/java17-debian12` → `java21-debian12`
- `java-version` hevet til 21 i alle tre GitHub Actions-workflows

## Testing
- [x] Enhetstester
- [x] Manuell testing lokalt
- [ ] E2E-tester (ikke relevant)

## Notater
Toolchain er valgt fremfor `sourceCompatibility = VERSION_21` fordi den
styrer *hvilken* JDK som brukes, ikke bare hva bytecoden merkes som. Det
gir likt bygg lokalt og i CI. Samme mønster som melosys-skjema-api.
