### PR TITLE
NOJIRA Dokumenter lokal oppstart og fiks Azure-config i profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,72 @@ Kafka-consumer for vedtakshendelser:
    cd melosys-skattehendelser
    ```
 
-2. **Start lokale tjenester**:
+2. **Start lokale tjenester** (kjøres i `melosys-docker-compose`):
    ```bash
-   docker-compose up -d postgres kafka
-   # eller
-   make start-all  # i melosys-docker-compose
+   docker compose up -d postgres kafka mock-oauth2-server mock-oauth2-login-proxy melosys-mock
    ```
+
+   Alle fem trengs. `mock-oauth2-server` publiserer ikke port 8082 til host –
+   det er `mock-oauth2-login-proxy` som gjør det. Uten den feiler oppstart med
+   `MetaDataNotAvailableException: Could not retrieve metadata from url:
+   http://host.docker.internal:8082/isso/.well-known/openid-configuration`.
 
 3. **Bygg og start applikasjonen**:
    ```bash
    ./gradlew bootRun --args='--spring.profiles.active=local'
    ```
+
+   Applikasjonen kjører på port **8089**. Helsesjekk: `http://localhost:8089/internal/health`.
+
+   **Profiler:** `local`, `q2` og `ske` er de kjørbare profilene (`test` finnes også,
+   men brukes kun av testkjøring). Alle tre kjøres lokalt (mot lokal Postgres/Kafka og
+   lokal mock-oauth2); `q2` og `ske` peker Sigrun mot henholdsvis sigrun-q2 og sigrun-ske.
+   I NAIS brukes default-profilen, der alle `AZURE_*`-variabler injiseres av plattformen.
+
+   Profilnavn kombineres ikke med bindestrek – `local-q2` er ett enkelt (ikke-eksisterende)
+   profilnavn, ikke «local + q2». Da lastes kun `application.yaml`, og oppstart feiler med
+   en uløst placeholder (f.eks. `Could not resolve placeholder 'SIGRUN_REST_URL'`).
+
+   Bruk `q2` eller `ske` **alene** – ikke `local,q2`. `application-local.yaml` setter
+   `sigrun.rest.url` direkte, mens q2/ske setter `SIGRUN_REST_URL` som `application.yaml`
+   interpolerer. Den direkte verdien vinner uansett profilrekkefølge, så `local,q2` henter
+   et ekte Azure-token for sigrun-q2 og kaller deretter den lokale mocken.
+
+   Skal du kalle ekte Sigrun i q2/ske, sett `AZURE_APP_CLIENT_ID` og `AZURE_APP_CLIENT_SECRET`
+   som miljøvariabler – de overstyrer profilfila. Verdiene må være den ekte Azure-appen til
+   melosys-skattehendelser (den som har tilgangsrolle på `api://dev-fss.team-inntekt.sigrun-q2`);
+   `melosys-localhost` finnes kun i lokal mock-oauth2 og gir
+   `AADSTS501051: Application 'melosys-localhost' is not assigned to a role`.
+   Spør i teamkanalen, eller hent dem fra dev-clusteret – pass på at konteksten er `dev-gcp`,
+   ikke prod:
+   ```bash
+   kubectl --context dev-gcp -n teammelosys exec deploy/melosys-skattehendelser \
+     -- printenv AZURE_APP_CLIENT_ID AZURE_APP_CLIENT_SECRET
+   ```
+
+   Innkommende JWT valideres mot `AZURE_APP_ACCEPTED_AUDIENCE` (defaulter til
+   `AZURE_APP_CLIENT_ID` når den ikke er satt, slik NAIS forventer). Lokalt står den til
+   `melosys-localhost` i profilfilene, så admin-kall under fortsetter å virke selv når
+   `AZURE_APP_CLIENT_ID` overstyres med ekte Azure-app.
+
+   Pass på at du **ikke** har `AZURE_APP_WELL_KNOWN_URL` satt til en ikke-URL (f.eks. `dummy`)
+   i run-konfigurasjonen; det gir samme bindingsfeil.
+
+4. **Kall admin-endepunkter lokalt** – krever både JWT og API-nøkkel:
+   ```bash
+   TOKEN=$(curl -s -X POST http://host.docker.internal:8082/isso/token \
+     -d grant_type=client_credentials -d client_id=melosys-localhost \
+     -d client_secret=lol -d scope=melosys-localhost | jq -r .access_token)
+
+   curl -H "Authorization: Bearer $TOKEN" \
+        -H "X-SKATTEHENDELSER-ADMIN-APIKEY: dummy" \
+        http://localhost:8089/admin/hendelseprosessering/status
+   ```
+
+   Merk: token må hentes fra `/isso/token`, ikke `/isso/oauth2/v2.0/token` –
+   sistnevnte gir en issuer som ikke matcher discovery-dokumentet, og gir 401.
+   `scope` må matche `AZURE_APP_ACCEPTED_AUDIENCE`; ellers får du
+   `JWT audience rejected: [melosys-localhost]` i loggen og 401 fra endepunktet.
 
 ### Testing
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,6 +14,9 @@ sigrun:
 
 # JWT Configuration for local development
 AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
+# Audience for innkommende token. Egen variabel slik at AZURE_APP_CLIENT_ID kan settes til
+# ekte Azure-app (for utgaende Sigrun-kall) uten at lokale admin-kall slutter a virke.
+AZURE_APP_ACCEPTED_AUDIENCE: melosys-localhost
 AZURE_APP_CLIENT_ID: melosys-localhost
 AZURE_APP_CLIENT_SECRET: lol
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: http://host.docker.internal:8082/isso/oauth2/v2.0/token

--- a/src/main/resources/application-q2.yaml
+++ b/src/main/resources/application-q2.yaml
@@ -9,8 +9,19 @@ spring:
     locations: classpath:db/migration
     enabled: true
 
-# Azure AD JWT configuration - AZURE_APP_WELL_KNOWN_URL injiseres automatisk av NAIS
+# Azure AD. I NAIS injiseres disse automatisk (default-profilen brukes der).
+# Denne profilen kjøres kun lokalt, så verdiene må stå her.
+# Innkommende JWT valideres mot lokal mock-oauth2 (via mock-oauth2-login-proxy på 8082).
+AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
+# Audience for innkommende token. Egen variabel slik at AZURE_APP_CLIENT_ID kan settes til
+# ekte Azure-app (for utgående Sigrun-kall) uten at lokale admin-kall slutter å virke.
+AZURE_APP_ACCEPTED_AUDIENCE: melosys-localhost
+
+# Utgående token til ekte Sigrun i q2. Sett AZURE_APP_CLIENT_ID/SECRET som miljøvariabler
+# (miljøvariabler overstyrer denne fila) hvis du faktisk skal kalle sigrun-q2.
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token
+AZURE_APP_CLIENT_ID: melosys-localhost
+AZURE_APP_CLIENT_SECRET: lol
 
 CLUSTER_SIGRUN: dev-fss
 APP_NAME_SIGRUN: sigrun-q2

--- a/src/main/resources/application-ske.yaml
+++ b/src/main/resources/application-ske.yaml
@@ -9,12 +9,24 @@ spring:
     locations: classpath:db/migration
     enabled: true
 
-# Azure AD JWT configuration - AZURE_APP_WELL_KNOWN_URL injiseres automatisk av NAIS
+# Azure AD. I NAIS injiseres disse automatisk (default-profilen brukes der).
+# Denne profilen kjøres kun lokalt, så verdiene må stå her.
+# Innkommende JWT valideres mot lokal mock-oauth2 (via mock-oauth2-login-proxy på 8082).
+AZURE_APP_WELL_KNOWN_URL: http://host.docker.internal:8082/isso/.well-known/openid-configuration
+# Audience for innkommende token. Egen variabel slik at AZURE_APP_CLIENT_ID kan settes til
+# ekte Azure-app (for utgående Sigrun-kall) uten at lokale admin-kall slutter å virke.
+AZURE_APP_ACCEPTED_AUDIENCE: melosys-localhost
+
+# Utgående token til ekte Sigrun. Sett AZURE_APP_CLIENT_ID/SECRET som miljøvariabler
+# (miljøvariabler overstyrer denne fila) hvis du faktisk skal kalle sigrun-ske.
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token
+AZURE_APP_CLIENT_ID: melosys-localhost
+AZURE_APP_CLIENT_SECRET: lol
 
 CLUSTER_SIGRUN: dev-fss
 APP_NAME_SIGRUN: sigrun-q4
 KAFKA_BROKERS: localhost:29092
 KAFKA_VEDTAK_TOPIC: teammelosys.melosys-hendelser-local
+KAFKA_SKATTEHENDELSE_TOPIC: teammelosys.skattehendelser.v1-local
 SIGRUN_REST_URL: https://team-inntekt-proxy.dev-fss-pub.nais.io/proxy/sigrun-ske
 ADMIN_API_KEY: dummy

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,7 +68,7 @@ no.nav.security.jwt:
   issuer:
     aad:
       discovery-url: ${AZURE_APP_WELL_KNOWN_URL}
-      accepted-audience: ${AZURE_APP_CLIENT_ID}
+      accepted-audience: ${AZURE_APP_ACCEPTED_AUDIENCE:${AZURE_APP_CLIENT_ID}}
 
 management:
   endpoints:


### PR DESCRIPTION
Dokumenterer hva som faktisk skal til for å kjøre applikasjonen lokalt, og fyller inn Azure-konfigurasjonen som manglet i q2- og ske-profilene.

Lokal oppstart hadde flere feller der feilmeldingen ikke pekte på årsaken. `mock-oauth2-server` publiserer ikke port 8082 til host — det gjør `mock-oauth2-login-proxy` — så uten den feiler oppstart med `MetaDataNotAvailableException`. Profilnavn kombineres ikke med bindestrek, så `local-q2` leses som ett ikke-eksisterende profilnavn. q2- og ske-profilene manglet `AZURE_APP_WELL_KNOWN_URL` og client id/secret som NAIS ellers injiserer, og **ske-profilen manglet `KAFKA_SKATTEHENDELSE_TOPIC` og kunne derfor ikke starte i det hele tatt** (`application.yaml` interpolerer den uten default).

- README: nødvendige containere, hvilke profiler som finnes, og hvordan admin-endepunktene kalles med JWT + API-nøkkel
- q2/ske: Azure-variabler fylt inn, og `KAFKA_SKATTEHENDELSE_TOPIC` lagt til i ske
- `AZURE_APP_ACCEPTED_AUDIENCE` skilt fra client id i alle tre lokale profiler, så man kan sette ekte Azure-app for utgående Sigrun-kall uten at lokale admin-kall slutter å virke

## Testing
- [x] Testsuiten uendret (samme preeksisterende Testcontainers-feil som på master)
- [ ] Manuell testing lokalt
- [ ] E2E-tester (ikke relevant)

## Notater
**Den ene linja som treffer prod:** `application.yaml` endres til
`accepted-audience: ${AZURE_APP_ACCEPTED_AUDIENCE:${AZURE_APP_CLIENT_ID}}`.
Verifisert at NAIS ikke injiserer `AZURE_APP_ACCEPTED_AUDIENCE` (den står ikke i nais/reference-settet og ikke i `nais/nais.yml`), at nested `${A:${B}}` løses korrekt i Spring Boot, at typen (`List<String>`) bevares, og at fail-fast beholdes når begge er usatt. Default-profilen i prod løser dermed til samme verdi som før.

Verdt å merke: `nais/nais.yml` har `envFrom: secret`, som er en flate der variabelen i prinsippet kan settes uten at det synes i dette repoet.

README-en advarer nå eksplisitt mot `--spring.profiles.active=local,q2`. `application-local.yaml` setter `sigrun.rest.url` direkte, mens q2/ske setter `SIGRUN_REST_URL` som `application.yaml` interpolerer — den direkte verdien vinner uansett profilrekkefølge, så kombinasjonen henter et ekte Azure-token for sigrun-q2 og kaller deretter den lokale mocken.