### PR TITLE
NOJIRA Ignorer lokale analyse- og kjøringsartefakter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,25 @@ out/
 
 ##
 .DS_Store
+
+### Lokale analyse- og kjøringsartefakter ###
+# Uttrekk og kjøringsresultater fra miljøer med reelle persondata skal aldri i
+# git. Reglene er endelsesbaserte i repo-roten framfor navnebaserte: navnebaserte
+# regler dekker bare filnavn noen allerede har brukt, og et nytt navn slipper rett
+# gjennom. Ingen sporet fil i roten bruker disse endelsene.
+#
+# NB: .gitignore er en bekvemmelighet, ikke en kontroll - `git add -f` går rundt
+# den. Varig sikring mot persondata i git er hook/CI-skanning, ikke ignore-regler.
+/prod*/
+/anon*/
+/analyse-*/
+/*.json
+/*.ndjson
+/*.csv
+/*.txt
+/*.xlsx
+/*.zip
+/*.html
+/*.md
+!/README.md
+!/AGENTS.md


### PR DESCRIPTION
Legger til `.gitignore`-regler for `prod*/`, `anon*/`, `analyse-*/` og data-/rapportendelser i repo-roten, samt maskinlokal verktøykonfigurasjon.

Lokale uttrekk og kjøringsresultater hoper seg opp i repo-roten. Slike filer kan inneholde persondata fra miljøer med reelle data, og har ingenting i git å gjøre. Uten regler er de ett `git add -A` fra å bli committet.

Reglene er endelsesbaserte i roten framfor navnebaserte, fordi navnebaserte regler bare dekker filnavn noen allerede har brukt — et nytt navn slipper rett gjennom. `README.md` og er unntatt. Ingen sporet fil i repo-roten bruker de øvrige endelsene, så regelen treffer ingenting som er i bruk i dag.

- Endelsene er ankret til roten med skråstrek. Uten ankring ville `*.xlsx` og `*.zip` også skjult testfixtures under `src/test/resources/`
- For `.claude/` ignoreres kun `settings.local.json`, ikke hele katalogen, slik at `.claude/skills/` kan spores som delt teamverktøy hvis teamet vil det

## Testing
- [x] Ingen sporet fil blir ignorert (`git ls-files | xargs git check-ignore` er tom)
- [ ] Manuell testing lokalt (ikke relevant)
- [ ] E2E-tester (ikke relevant)

## Notater
`.gitignore` er en bekvemmelighet, ikke en kontroll — `git add -f` går rundt den. Varig sikring bør være hook- eller CI-skanning, og bør tas som egen sak.