### PR TITLE
8219 Kall Sigrun sitt pensjonsgivendeinntekt-API med POST

### DIFF
--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunConsumerConfig.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunConsumerConfig.kt
@@ -46,7 +46,6 @@ class SigrunConsumerConfig(@Value("\${sigrun.rest.url}") private val url: String
             .defaultHeaders {
                 it.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 it.add("Nav-Consumer-Id", CONSUMER_ID)
-                it.add("rettighetspakke", RETTIGHETSPAKKE)
             }
             .build()
     )
@@ -67,6 +66,5 @@ class SigrunConsumerConfig(@Value("\${sigrun.rest.url}") private val url: String
 
     companion object {
         private const val CONSUMER_ID = "melosys-skattehendelser"
-        private const val RETTIGHETSPAKKE = "navtrygdeavgift"
     }
 }

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -13,14 +13,12 @@ import reactor.core.publisher.Mono
 
 private val log = io.github.oshai.kotlinlogging.KotlinLogging.logger {}
 
-/**
- * Sigrun fjernet GET-varianten av dette endepunktet fordi den krevde personidentifikator i
- * headeren Nav-Personident. Etter fjerningen svarte GET 403 insufficient_scope, ikke 404/405,
- * så feilen så ut som et tilgangsproblem. POST tar de samme parametrene i body - inkludert
- * rettighetspakke, som tidligere var en default-header på WebClienten.
- */
 private const val RETTIGHETSPAKKE = "navtrygdeavgift"
 
+/**
+ * Feltnavnene er Sigrun sine (personident, ikke navPersonident). Rettighetspakke leses
+ * kun fra bodyen - den har ingen effekt som header.
+ */
 private data class PensjonsgivendeInntektForFolketrygdenRequest(
     val personident: String,
     val inntektsaar: String,

--- a/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
+++ b/src/main/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumer.kt
@@ -6,20 +6,40 @@ import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektRequest
 import no.nav.melosysskattehendelser.skatt.PensjonsgivendeInntektResponse
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
 private val log = io.github.oshai.kotlinlogging.KotlinLogging.logger {}
 
+/**
+ * Sigrun fjernet GET-varianten av dette endepunktet fordi den krevde personidentifikator i
+ * headeren Nav-Personident. Etter fjerningen svarte GET 403 insufficient_scope, ikke 404/405,
+ * så feilen så ut som et tilgangsproblem. POST tar de samme parametrene i body - inkludert
+ * rettighetspakke, som tidligere var en default-header på WebClienten.
+ */
+private const val RETTIGHETSPAKKE = "navtrygdeavgift"
+
+private data class PensjonsgivendeInntektForFolketrygdenRequest(
+    val personident: String,
+    val inntektsaar: String,
+    val rettighetspakke: String = RETTIGHETSPAKKE,
+)
+
 open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient) : PensjonsgivendeInntektConsumer {
     @Measured
     @Cacheable(value = ["pensjonsgivendeInntekt"], key = "#request.navPersonident + '-' + #request.inntektsaar")
     override fun hentPensjonsgivendeInntekt(request: PensjonsgivendeInntektRequest): PensjonsgivendeInntektResponse {
-        return webClient.get()
+        return webClient.post()
             .uri("/api/v1/pensjonsgivendeinntektforfolketrygden")
-            .header("Nav-Personident", request.navPersonident)
-            .header("inntektsaar", request.inntektsaar)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                PensjonsgivendeInntektForFolketrygdenRequest(
+                    personident = request.navPersonident,
+                    inntektsaar = request.inntektsaar
+                )
+            )
             .exchangeToMono { response ->
                 val status = response.statusCode()
                 when {
@@ -44,7 +64,7 @@ open class SigrunPensjonsgivendeInntektConsumer(private val webClient: WebClient
                             "PensjonsgivendeInntekt api feilet - status: $status" +
                                 ", inntektsaar: ${request.inntektsaar}" +
                                 ", Nav-Call-Id: ${response.requestHeader("Nav-Call-Id")}" +
-                                ", rettighetspakke: ${response.requestHeader("rettighetspakke")}" +
+                                ", rettighetspakke: $RETTIGHETSPAKKE" +
                                 ", Nav-Consumer-Id: ${response.requestHeader("Nav-Consumer-Id")}" +
                                 ", responseHeaders: ${response.loggbareResponseHeadere()}" +
                                 ", body: ${exception.responseBodyAsString.maskertOgAvkortet()}"

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -47,7 +47,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal hente inntekt`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141638")
+            createPostRequest("26468141638")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(200)
@@ -90,9 +90,54 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     }
 
     @Test
+    fun `skal sende personident, inntektsaar og rettighetspakke i body - ikke i header`() {
+        val navPersonident = "26468141647"
+        wireMockServer.stubFor(
+            createPostRequest(navPersonident)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(
+                            """
+                                {
+                                    "norskPersonidentifikator": "$navPersonident",
+                                    "inntektsaar": "2024",
+                                    "pensjonsgivendeInntekt": []
+                                }
+                            """.trimIndent()
+                        )
+                )
+        )
+
+        sigrunPensjonsgivendeInntektConsumer.hentPensjonsgivendeInntekt(
+            PensjonsgivendeInntektRequest(inntektsaar = "2024", navPersonident = navPersonident)
+        )
+
+        wireMockServer.verify(
+            WireMock.postRequestedFor(WireMock.urlPathEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
+                .withHeader(HttpHeaders.CONTENT_TYPE, WireMock.containing(MediaType.APPLICATION_JSON_VALUE))
+                // Sigrun fjernet GET-varianten nettopp fordi identen lå i headeren - den skal ikke sendes lenger.
+                .withoutHeader("Nav-Personident")
+                .withoutHeader("rettighetspakke")
+                .withRequestBody(
+                    WireMock.equalToJson(
+                        """
+                            {
+                                "personident": "$navPersonident",
+                                "inntektsaar": "2024",
+                                "rettighetspakke": "navtrygdeavgift"
+                            }
+                        """.trimIndent()
+                    )
+                )
+        )
+    }
+
+    @Test
     fun `skal håntere 404`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141637")
+            createPostRequest("26468141637")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(404)
@@ -114,7 +159,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal kaste feil med statuskode nar 2xx svar mangler body`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141639")
+            createPostRequest("26468141639")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(204)
@@ -131,7 +176,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal kaste feil med statuskode nar api svarer 500 uten body`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141640")
+            createPostRequest("26468141640")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(500)
@@ -148,7 +193,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal ikke tolke feilmelding-body fra 500 som tom inntekt`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141641")
+            createPostRequest("26468141641")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(500)
@@ -167,7 +212,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal logge statuskode, body og Nav-Call-Id ved 403`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141642")
+            createPostRequest("26468141642")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(403)
@@ -209,7 +254,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     fun `skal maskere personident i body og utelate ukjente response-headere`() {
         val navPersonident = "26468141643"
         wireMockServer.stubFor(
-            createGetRequest(navPersonident)
+            createPostRequest(navPersonident)
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(400)
@@ -240,7 +285,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         val navPersonident = "26468141644"
         val langBody = "<html>" + "x".repeat(20_000) + "</html>"
         wireMockServer.stubFor(
-            createGetRequest(navPersonident)
+            createPostRequest(navPersonident)
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(502)
@@ -264,7 +309,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal behandle 3xx som feil og ikke som manglende body`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141645")
+            createPostRequest("26468141645")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(302)
@@ -282,7 +327,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
     @Test
     fun `skal ikke tolke uventet body fra 200 som tom inntekt`() {
         wireMockServer.stubFor(
-            createGetRequest("26468141646")
+            createPostRequest("26468141646")
                 .willReturn(
                     WireMock.aResponse()
                         .withStatus(200)
@@ -310,7 +355,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         return logg.list.single { it.level == Level.ERROR }.formattedMessage
     }
 
-    private fun createGetRequest(navPersonident: String): MappingBuilder =
-        WireMock.get(WireMock.urlPathEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
-            .withHeader("Nav-Personident", WireMock.equalTo(navPersonident))
+    private fun createPostRequest(navPersonident: String): MappingBuilder =
+        WireMock.post(WireMock.urlPathEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
+            .withRequestBody(WireMock.matchingJsonPath("$.personident", WireMock.equalTo(navPersonident)))
 }

--- a/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
+++ b/src/test/kotlin/no/nav/melosysskattehendelser/skatt/sigrun/SigrunPensjonsgivendeInntektConsumerTest.kt
@@ -117,7 +117,7 @@ class SigrunPensjonsgivendeInntektConsumerTest {
         wireMockServer.verify(
             WireMock.postRequestedFor(WireMock.urlPathEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
                 .withHeader(HttpHeaders.CONTENT_TYPE, WireMock.containing(MediaType.APPLICATION_JSON_VALUE))
-                // Sigrun fjernet GET-varianten nettopp fordi identen lå i headeren - den skal ikke sendes lenger.
+                // Personident i header er ikke tillatt (personvern) - derfor negativ assert.
                 .withoutHeader("Nav-Personident")
                 .withoutHeader("rettighetspakke")
                 .withRequestBody(


### PR DESCRIPTION
Bytter inntektsoppslaget mot Sigrun fra GET til POST, og flytter personident, inntektsår og rettighetspakke fra HTTP-headere til request-body.

Team Inntekt har fjernet GET-varianten fordi den krevde personidentifikator i headeren `Nav-Personident`. Etter fjerningen svarer endepunktet 403 `insufficient_scope` i stedet for 404/405, så feilen så ut som et tokenproblem framfor et fjernet endepunkt. I prod hentes hendelser som normalt, mens hvert inntektsoppslag feiler, og ingenting publiseres videre til Melosys.
[MELOSYS-8219](https://nav.atlassian.net/browse/MELOSYS-8219)

- POST med body `{personident, inntektsaar, rettighetspakke}` i stedet for GET med `Nav-Personident` og `inntektsaar` som headere
- `rettighetspakke` flyttet fra default-header på WebClienten til bodyen
- Feilloggingen leste `rettighetspakke` fra request-headeren og ville logget `null` ved neste 403; leser nå konstanten

## Testing
- [x] Enhetstester — ny test pinner request-bodyen og at `Nav-Personident` ikke sendes
- [ ] Manuell testing lokalt — krever POST-støtte i melosys-mock
- [ ] E2E-tester

## Notater
Feltnavnet i bodyen er `personident`, ikke `navPersonident`. Hentet fra Sigrun sin api-docs (`PensjonsgivendeInntektForFolketrygdenRequest`), ikke utledet fra det gamle headernavnet.

Hendelses-endepunktet er ikke berørt og er fortsatt GET. Feilhåndteringen rundt kallet — 404 som slettet, avvisning av 2xx uten `norskPersonidentifikator`, maskering og avkorting av feilbody — er uendret.

melosys-mock må svare på POST på samme sti før lokal kjøring og e2e virker. Ikke gjort i denne PR-en.